### PR TITLE
set encoding to utf-8 so that build is platform independent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,8 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
fixes problem with building in maven when local setting has something different than utf-8, e.g. cp1252)