### PR TITLE
Version 0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,7 @@ Note that contrary to other existing libraries, this library has no external dep
 ## Using fxsvgimage as a maven/gradle dependency
 
 fxsvgimage is not yet available in maven central. Until it is you can still use a release as a maven or gradle dependency 
-through [jitpack](https://jitpack.io/). 
-
-[![Release](https://jitpack.io/v/hervegirod/fxsvgimage.svg)]
-https://jitpack.io/#hervegirod/fxsvgimage
+through [![Release](https://jitpack.io/v/hervegirod/fxsvgimage.svg)](https://jitpack.io/#hervegirod/fxsvgimage)
 
 For maven do the following:
 1. Add jitpack to your list of repositories i.e. in the `<repositories>` section add:

--- a/README.md
+++ b/README.md
@@ -5,8 +5,14 @@ complete documentation.
 Note that contrary to other existing libraries, this library has no external dependencies (including Batik)
 
 ## Using fxsvgimage as a maven/gradle dependency
+
 fxsvgimage is not yet available in maven central. Until it is you can still use a release as a maven or gradle dependency 
-through [jitpack](https://jitpack.io/). For maven do the following:
+through [jitpack](https://jitpack.io/). 
+
+[![Release](https://jitpack.io/v/hervegirod/fxsvgimage.svg)]
+https://jitpack.io/#hervegirod/fxsvgimage
+
+For maven do the following:
 1. Add jitpack to your list of repositories i.e. in the `<repositories>` section add:
 ```xml
     <repository>
@@ -19,7 +25,7 @@ through [jitpack](https://jitpack.io/). For maven do the following:
     <dependency>
       <groupId>com.github.hervegirod</groupId>
       <artifactId>fxsvgimage</artifactId>
-      <version>0.5.6</version>
+      <version>0.6</version>
     </dependency>
 ```
 See https://jitpack.io/ for info on the syntax for other build systems such as gradle, svt etc.

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Minor fixes:
- Bump junit version to latest
- Replace link to jitpack with the jitpack badge linking to the latest auto build of the release
- update the dependency example to the latest version.