### PR TITLE
use the core/manifest.mf for the MANIFEST.MF in the jar in the maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.girod</groupId>
     <artifactId>fxsvgimage</artifactId>
-    <version>1.0b1</version>
+    <version>1.0-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -85,6 +85,16 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.2</version>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.basedir}/src/core/manifest.mf</manifestFile>
+                    </archive>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
I missed the core/manifest.mf file in the maven build script so that the Automatic-module-name became different from what it is in the release file. This PR fixes that. Also we can keep the version in the pom.xml as 1.0-SNAPSHOT since it will be overwritten by the version number given in the github release anyway and keeping it in sync is both unnecessary and tedious.