### PR TITLE
Fix issue #72

### DIFF
--- a/src/core/org/girod/javafx/svgimage/SVGLoader.java
+++ b/src/core/org/girod/javafx/svgimage/SVGLoader.java
@@ -542,6 +542,21 @@ public class SVGLoader implements SVGTags {
       }
    }
 
+   private void preparseClipping(XMLNode xmlNode) {
+      Iterator<XMLNode> it = xmlNode.getChildren().iterator();
+      while (it.hasNext()) {
+         XMLNode childNode = it.next();
+         String name = childNode.getName();
+         switch (name) {
+            case CLIP_PATH_SPEC:
+            case MASK:
+               buildClipPath(childNode);
+               break;
+         }
+         preparseClipping(childNode);
+      }
+   }
+
    private SVGImage walk(XMLRoot xmlRoot) {
       String name = xmlRoot.getName();
       if (name.equals(SVG)) {
@@ -556,6 +571,7 @@ public class SVGLoader implements SVGTags {
          }
       }
       preparseStyles(xmlRoot);
+      preparseClipping(xmlRoot);
       buildNode(xmlRoot, root);
       return root;
    }

--- a/test/org/girod/javafx/svgimage/SVGLoaderClipPathGroupTest.java
+++ b/test/org/girod/javafx/svgimage/SVGLoaderClipPathGroupTest.java
@@ -1,0 +1,106 @@
+/*
+Copyright (c) 2025, Herve Girod
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Alternatively if you have any questions about this project, you can visit
+the project website at the project page on https://github.com/hervegirod/fxsvgimage
+ */
+package org.girod.javafx.svgimage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import java.net.URL;
+import javafx.collections.ObservableList;
+import javafx.scene.Group;
+import javafx.scene.Node;
+import javafx.scene.shape.Line;
+import javafx.scene.shape.Rectangle;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Unit tests for clip-path on group elements.
+ *
+ * @since 1.4
+ */
+public class SVGLoaderClipPathGroupTest {
+   private static double DELTA = 0.001d;
+
+   public SVGLoaderClipPathGroupTest() {
+   }
+
+   @BeforeClass
+   public static void setUpClass() {
+   }
+
+   @AfterClass
+   public static void tearDownClass() {
+   }
+
+   @Before
+   public void setUp() {
+   }
+
+   @After
+   public void tearDown() {
+   }
+
+   /**
+    * Test of load method, of class SVGLoader. Test with clip-path on a group.
+    */
+   @Test
+   public void testClipPathOnGroup() throws Exception {
+      System.out.println("SVGLoaderClipPathGroupTest : testClipPathOnGroup");
+      URL url = this.getClass().getResource("clip-path-group.svg");
+      SVGImage result = SVGLoader.load(url);
+      assertNotNull("SVGImage should not be null", result);
+
+      ObservableList<Node> children = result.getChildren();
+      assertEquals("Must have one child", 1, children.size());
+      Node child = children.get(0);
+      assertTrue("Child must be a Group", child instanceof Group);
+      Group group = (Group) child;
+
+      Node clip = group.getClip();
+      assertNotNull("Group clip should be set", clip);
+      assertTrue("Clip should be a Rectangle", clip instanceof Rectangle);
+      Rectangle rect = (Rectangle) clip;
+      assertEquals("clip x", 50, rect.getX(), DELTA);
+      assertEquals("clip y", 50, rect.getY(), DELTA);
+      assertEquals("clip width", 100, rect.getWidth(), DELTA);
+      assertEquals("clip height", 100, rect.getHeight(), DELTA);
+
+      ObservableList<Node> groupChildren = group.getChildren();
+      assertEquals("Group should have one child", 1, groupChildren.size());
+      assertTrue("Group child must be a Line", groupChildren.get(0) instanceof Line);
+   }
+}

--- a/test/org/girod/javafx/svgimage/clip-path-group.svg
+++ b/test/org/girod/javafx/svgimage/clip-path-group.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+   <g clip-path="url(#plot-clip)">
+      <line x1="100" y1="0" x2="100" y2="200" stroke="red" stroke-width="3"/>
+   </g>
+   <defs>
+      <clipPath id="plot-clip">
+         <rect width="100" height="100" x="50" y="50"/>
+      </clipPath>
+   </defs>
+</svg>


### PR DESCRIPTION
Fix issue #72

This pull request adds support for preparsing clipping paths (clip-path and mask elements) in the SVG loading process and introduces a corresponding unit test to ensure correct handling of clip-paths on group elements. The main functional update is the addition of a preparsing step for clipping elements, which ensures that clip paths and masks are built before the SVG node tree is constructed.

**SVG Loader improvements:**

* Added a new `preparseClipping` method to `SVGLoader.java` that recursively processes SVG nodes to build clip-path and mask definitions before building the SVG node tree. This ensures that clipping information is available when constructing the scene graph.
* Integrated the `preparseClipping` step into the main SVG loading workflow by calling it in the `walk` method after style preparsing.

**Testing enhancements:**

* Added a new test class `SVGLoaderClipPathGroupTest.java` that verifies correct application of a clip-path to a group element, checking both the presence and geometry of the clip as well as the structure of the group’s children.