### PR TITLE
Fix #90: Documentation/Behavior Mismatch: scale(double) returns a new instance instead of initial object

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+# 1.7
+- Fix #90: Documentation/Behavior Mismatch: scale(double) returns a new instance instead of initial object. Now the scale do not create a new image, but
+  change the scale of the initial image. To create a new image, use the scale(duvle, true), or clone the image
+
 # 1.6
  - Add a css library, using SAC and cssParser
  - Fix #85: Add support for units in shapes lengths and positions

--- a/src/core/org/girod/javafx/svgimage/SVGImage.java
+++ b/src/core/org/girod/javafx/svgimage/SVGImage.java
@@ -582,7 +582,7 @@ public class SVGImage extends Group implements Cloneable {
             this.nodes.putAll(image.nodes);
             this.animations.clear();
             this.animations.addAll(image.animations);
-            this.getChildren().removeAll();
+            this.getChildren().clear();
             this.getChildren().addAll(image.getChildren());
             this.setTranslateX(image.getTranslateX());
             this.setTranslateY(image.getTranslateY());

--- a/src/core/org/girod/javafx/svgimage/SVGImage.java
+++ b/src/core/org/girod/javafx/svgimage/SVGImage.java
@@ -62,6 +62,7 @@ public class SVGImage extends Group implements Cloneable {
    private static SVGSnapshotParameters SNAPSHOT_PARAMS = null;
    private final Map<String, Node> nodes = new HashMap<>();
    private List<Animation> animations = new ArrayList<>();
+   private boolean isPlayingAnimations = false;
    private List<URL> stylesheets = new ArrayList<>();
    private final SVGContent content;
    private double currentScale = 1d;
@@ -243,6 +244,7 @@ public class SVGImage extends Group implements Cloneable {
    }
 
    private void playAnimationsImpl() {
+      this.isPlayingAnimations = true;
       if (!animations.isEmpty()) {
          Iterator<Animation> it = animations.iterator();
          while (it.hasNext()) {
@@ -250,6 +252,15 @@ public class SVGImage extends Group implements Cloneable {
             tr.play();
          }
       }
+   }
+
+   /**
+    * Return true if the animations are playing.
+    *
+    * @return true if the animations are playing
+    */
+   public boolean isPlayingAnimations() {
+      return isPlayingAnimations;
    }
 
    /**
@@ -271,6 +282,7 @@ public class SVGImage extends Group implements Cloneable {
    }
 
    private void stopAnimationsImpl() {
+      this.isPlayingAnimations = false;
       if (!animations.isEmpty()) {
          Iterator<Animation> it = animations.iterator();
          while (it.hasNext()) {
@@ -578,6 +590,10 @@ public class SVGImage extends Group implements Cloneable {
             }
          }
          if (!createNew) {
+            boolean _isPlayingAnimations = isPlayingAnimations;
+            if (isPlayingAnimations) {
+               this.stopAnimations();
+            }
             this.nodes.clear();
             this.nodes.putAll(image.nodes);
             this.animations.clear();
@@ -588,6 +604,9 @@ public class SVGImage extends Group implements Cloneable {
             this.setTranslateY(image.getTranslateY());
             this.getTransforms().clear();
             this.getTransforms().addAll(image.getTransforms());
+            if (_isPlayingAnimations) {
+               this.playAnimations();
+            }
             return this;
          }
          return image;

--- a/src/core/org/girod/javafx/svgimage/SVGImage.java
+++ b/src/core/org/girod/javafx/svgimage/SVGImage.java
@@ -56,9 +56,9 @@ import org.girod.javafx.svgimage.xml.parsers.SVGLibraryException;
 /**
  * The resulting SVG image. It is a JavaFX Nodes tree.
  *
- * @version 1.5
+ * @version 1.7
  */
-public class SVGImage extends Group {
+public class SVGImage extends Group implements Cloneable {
    private static SVGSnapshotParameters SNAPSHOT_PARAMS = null;
    private final Map<String, Node> nodes = new HashMap<>();
    private List<Animation> animations = new ArrayList<>();
@@ -85,38 +85,38 @@ public class SVGImage extends Group {
       this.content = content;
    }
 
-   /** 
-    * Set the image associated file (can  be null).
-    * 
+   /**
+    * Set the image associated file (can be null).
+    *
     * @param file the file
     */
    public void setFile(File file) {
       this.file = file;
    }
 
-   /** 
-    * Return the image associated file (can  be null).
-    * 
+   /**
+    * Return the image associated file (can be null).
+    *
     * @return the file
-    */   
+    */
    public File getFile() {
       return file;
    }
-   
+
    /**
     * Set the stylesheets of the SVG content.
     *
     * @param stylesheets the stylesheets
-    */   
+    */
    public void setSVGStylesheets(List<URL> stylesheets) {
       this.stylesheets = stylesheets;
-   }   
-   
+   }
+
    /**
     * Return the stylesheets of the SVG content.
     *
     * @return the stylesheets
-    */   
+    */
    public List<URL> getSVGStylesheets() {
       return stylesheets;
    }
@@ -140,8 +140,8 @@ public class SVGImage extends Group {
    }
 
    /**
-    * Create a region containing this image. Note that the region will only be created once. This region will allow to
-    * use the image in a layout (for example a BorderPane, or a StackPane), and redimension the image accordingly.
+    * Create a region containing this image. Note that the region will only be created once. This region will allow to use the image in a layout (for
+    * example a BorderPane, or a StackPane), and redimension the image accordingly.
     *
     * @return the region
     */
@@ -163,24 +163,24 @@ public class SVGImage extends Group {
    }
 
    /**
-    * Set the default SnapshotParameters to use when creating snapshots. The default is null, which means that a
-    * default SnapshotParameters will be created when creating a snapshot.
+    * Set the default SnapshotParameters to use when creating snapshots. The default is null, which means that a default SnapshotParameters will be
+    * created when creating a snapshot.
     *
     * @param params the default SnapshotParameters
     */
    public static void setDefaultSnapshotParameters(SnapshotParameters params) {
       SNAPSHOT_PARAMS = new SVGSnapshotParameters(params);
    }
-   
+
    /**
-    * Set the default SnapshotParameters to use when creating snapshots. The default is null, which means that a
-    * default SnapshotParameters will be created when creating a snapshot.
+    * Set the default SnapshotParameters to use when creating snapshots. The default is null, which means that a default SnapshotParameters will be
+    * created when creating a snapshot.
     *
     * @param params the default SnapshotParameters
     */
    public static void setDefaultSnapshotParameters(SVGSnapshotParameters params) {
       SNAPSHOT_PARAMS = params;
-   }   
+   }
 
    /**
     * Return the default SnapshotParameters used when creating a snapshot.
@@ -279,9 +279,10 @@ public class SVGImage extends Group {
          }
       }
    }
-   
+
    /**
-    * Return the width of the image viewort. It will use the viewport to get the width if the viewport exists, else it willl get the width of the content.
+    * Return the width of the image viewort. It will use the viewport to get the width if the viewport exists, else it willl get the width of the
+    * content.
     *
     * @return the width
     */
@@ -291,7 +292,7 @@ public class SVGImage extends Group {
       } else {
          return getContentWidth();
       }
-   }   
+   }
 
    /**
     * Return the width of the image. Defer to {@link Viewport#getBestWidth()}.
@@ -301,7 +302,7 @@ public class SVGImage extends Group {
    public double getWidth() {
       return getViewportWidth();
    }
-   
+
    /**
     * Return the width of the image content.
     *
@@ -309,7 +310,7 @@ public class SVGImage extends Group {
     */
    public double getContentWidth() {
       return this.getLayoutBounds().getWidth();
-   }   
+   }
 
    /**
     * Return the width of the image, taking into account the scaling of the svg image.
@@ -328,9 +329,10 @@ public class SVGImage extends Group {
    public double getHeight() {
       return getViewportHeight();
    }
-   
+
    /**
-    * Return the height of the image viewort. It will use the viewport to get the height if the viewport exists, else it willl get the height of the content.
+    * Return the height of the image viewort. It will use the viewport to get the height if the viewport exists, else it willl get the height of the
+    * content.
     *
     * @return the height
     */
@@ -340,7 +342,8 @@ public class SVGImage extends Group {
       } else {
          return getContentHeight();
       }
-   }   
+   }
+
    /**
     * Return the height of the image content.
     *
@@ -348,7 +351,7 @@ public class SVGImage extends Group {
     */
    public double getContentHeight() {
       return this.getLayoutBounds().getHeight();
-   }      
+   }
 
    /**
     * Return the height of the image, taking into account the scaling of the svg image.
@@ -489,7 +492,7 @@ public class SVGImage extends Group {
       WritableImage image = snapshotImpl(jfxParams);
       return image;
    }
-   
+
    /**
     * Convert the Node tree to an image.
     *
@@ -501,7 +504,7 @@ public class SVGImage extends Group {
       params.applyViewportType(this);
       WritableImage image = snapshotImpl(jfxParams);
       return image;
-   }   
+   }
 
    /**
     * Convert the Node tree to an image.
@@ -516,6 +519,18 @@ public class SVGImage extends Group {
 
    private WritableImage snapshotImplInJFX(SnapshotParameters params) {
       WritableImage image = this.snapshot(params, null);
+      return image;
+   }
+
+   /**
+    * Clone the SVGImage. Will call {@link #scale(double, boolean)} with a scale of 1 and crrte a new image.
+    *
+    * @return the cloned SVGImage
+    */
+   @Override
+   public SVGImage clone() {
+      // don't use super.clone bevause we will create a new image group directly
+      SVGImage image = scale(1d, true);
       return image;
    }
 
@@ -567,6 +582,13 @@ public class SVGImage extends Group {
             this.nodes.putAll(image.nodes);
             this.animations.clear();
             this.animations.addAll(image.animations);
+            this.getChildren().removeAll();
+            this.getChildren().addAll(image.getChildren());
+            this.setTranslateX(image.getTranslateX());
+            this.setTranslateY(image.getTranslateY());
+            this.getTransforms().clear();
+            this.getTransforms().addAll(image.getTransforms());
+            return this;
          }
          return image;
       }
@@ -583,8 +605,7 @@ public class SVGImage extends Group {
    }
 
    /**
-    * Scale the image to a specified width. If <code>createNew</code> is <code>true</code>, then return the initial
-    * SVGImage.
+    * Scale the image to a specified width. If <code>createNew</code> is <code>true</code>, then return the initial SVGImage.
     *
     * @param width the width of the scaled image
     * @param createNew true to creata a new image
@@ -601,13 +622,11 @@ public class SVGImage extends Group {
    /**
     * Saves a snapshot of the image.
     *
-    * This method will throw a {@link org.girod.javafx.svgimage.xml.parsers.SVGLibraryException} if the snapshot
-    * generation generated an exception <b>and</b> {@link GlobalConfig#getExceptionsHandling()} is set to
-    * {@link ExceptionsHandling#RETROW_EXCEPTION}. It means that by default the method will simply return false if it
-    * could not save the snapshot.
+    * This method will throw a {@link org.girod.javafx.svgimage.xml.parsers.SVGLibraryException} if the snapshot generation generated an exception
+    * <b>and</b> {@link GlobalConfig#getExceptionsHandling()} is set to {@link ExceptionsHandling#RETROW_EXCEPTION}. It means that by default the
+    * method will simply return false if it could not save the snapshot.
     *
-    * Reasons for the save to not being able to generate the snapshot are the directory being read-only, or swing not
-    * available.
+    * Reasons for the save to not being able to generate the snapshot are the directory being read-only, or swing not available.
     *
     * @param params the parameters
     * @param format the format
@@ -633,13 +652,11 @@ public class SVGImage extends Group {
    /**
     * Saves a snapshot of the image.
     *
-    * This method will throw a {@link org.girod.javafx.svgimage.xml.parsers.SVGLibraryException} if the snapshot
-    * generation generated an exception <b>and</b> {@link GlobalConfig#getExceptionsHandling()} is set to
-    * {@link ExceptionsHandling#RETROW_EXCEPTION}. It means that by default the method will simply return false if it
-    * could not save the snapshot.
+    * This method will throw a {@link org.girod.javafx.svgimage.xml.parsers.SVGLibraryException} if the snapshot generation generated an exception
+    * <b>and</b> {@link GlobalConfig#getExceptionsHandling()} is set to {@link ExceptionsHandling#RETROW_EXCEPTION}. It means that by default the
+    * method will simply return false if it could not save the snapshot.
     *
-    * Reasons for the save to not being able to generate the snapshot are the directory being read-only, or swing not
-    * available.
+    * Reasons for the save to not being able to generate the snapshot are the directory being read-only, or swing not available.
     *
     * @param format the format
     * @param file the file

--- a/src/core/org/girod/javafx/svgimage/fxsvgimage.properties
+++ b/src/core/org/girod/javafx/svgimage/fxsvgimage.properties
@@ -1,2 +1,2 @@
-version=1.6
-date=30/03/2026
+version=1.7
+date=19/04/2026

--- a/src/cssparser/com/steadystate/css/parser/SACParserCSS1.java
+++ b/src/cssparser/com/steadystate/css/parser/SACParserCSS1.java
@@ -6,12 +6,10 @@ import org.w3c.css.sac.CSSParseException;
 import org.w3c.css.sac.Condition;
 import org.w3c.css.sac.LexicalUnit;
 import org.w3c.css.sac.Locator;
-import org.w3c.css.sac.Parser;
 import org.w3c.css.sac.Selector;
 import org.w3c.css.sac.SelectorList;
 import org.w3c.css.sac.SimpleSelector;
 
-import com.steadystate.css.parser.ParserUtils;
 
 /**
  * @author <a href="mailto:davidsch@users.sourceforge.net">David Schweinsberg</a>

--- a/test/org/girod/javafx/svgimage/SVGImageScaled2Test.java
+++ b/test/org/girod/javafx/svgimage/SVGImageScaled2Test.java
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2022, Hervé Girod
+Copyright (c) 2022, 2026 Hervé Girod
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -44,7 +44,7 @@ import javafx.scene.image.Image;
 /**
  * Unit tests for generating scaled images.
  *
- * @since 1.0
+ * @version 1.7
  */
 public class SVGImageScaled2Test {
    private static double DELTA = 0.001d;
@@ -77,23 +77,6 @@ public class SVGImageScaled2Test {
       URL url = this.getClass().getResource("rect50.svg");
       SVGImage result = SVGLoader.load(url);
       result = result.scaleTo(25);
-      Image img = result.toImage();
-      assertNotNull("Image must exist", img);
-      double width = img.getWidth();
-      double height = img.getHeight();
-      assertEquals("width", 25, width, DELTA);
-      assertEquals("height", 25, height, DELTA);
-   }
-
-   /**
-    * Test of generating a scaled image.
-    */
-   @Test
-   public void testScaledImage2() {
-      System.out.println("SVGImageScaled2Test : testScaledImage2");
-      URL url = this.getClass().getResource("rect50.svg");
-      SVGImage result = SVGLoader.load(url);
-      result = result.scale(0.5d);
       Image img = result.toImage();
       assertNotNull("Image must exist", img);
       double width = img.getWidth();

--- a/test/org/girod/javafx/svgimage/SVGImageScaled3Test.java
+++ b/test/org/girod/javafx/svgimage/SVGImageScaled3Test.java
@@ -1,0 +1,145 @@
+/*
+Copyright (c) 2026, Hervé Girod
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Alternatively if you have any questions about this project, you can visit
+the project website at the project page on https://github.com/hervegirod/fxsvgimage
+ */
+package org.girod.javafx.svgimage;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import java.net.URL;
+import javafx.scene.image.Image;
+
+/**
+ * Unit tests for generating scaled images.
+ *
+ * @since 1.7
+ */
+public class SVGImageScaled3Test {
+   private static double DELTA = 0.001d;
+
+   public SVGImageScaled3Test() {
+   }
+
+   @BeforeClass
+   public static void setUpClass() {
+   }
+
+   @AfterClass
+   public static void tearDownClass() {
+   }
+
+   @Before
+   public void setUp() {
+   }
+
+   @After
+   public void tearDown() {
+   }
+
+   /**
+    * Test of generating a scaled image.
+    */
+   @Test
+   public void testScaledNewImage() {
+      System.out.println("SVGImageScaledTest : testScaledNewImage");
+      URL url = this.getClass().getResource("rect50.svg");
+      SVGImage result = SVGLoader.load(url);
+      Image img = result.toImage();
+      assertNotNull("Image must exist", img);
+      double width = img.getWidth();
+      double height = img.getHeight();
+      assertEquals("width", 50, width, DELTA);
+      assertEquals("height", 50, height, DELTA);
+      
+      SVGImage result2 = result.scale(2d, true);
+      assertFalse("Must be a new image", result == result2);
+      img = result2.toImage();
+      assertNotNull("Image must exist", img);
+      width = img.getWidth();
+      height = img.getHeight();
+      assertEquals("width", 100, width, DELTA);
+      assertEquals("height", 100, height, DELTA);      
+   }
+   
+   /**
+    * Test of scaling a existing image.
+    */
+   @Test
+   public void testScaledExistingImage() {
+      System.out.println("SVGImageScaledTest : testScaledExistingImage");
+      URL url = this.getClass().getResource("rect50.svg");
+      SVGImage result = SVGLoader.load(url);
+      Image img = result.toImage();
+      assertNotNull("Image must exist", img);
+      double width = img.getWidth();
+      double height = img.getHeight();
+      assertEquals("width", 50, width, DELTA);
+      assertEquals("height", 50, height, DELTA);
+      
+      SVGImage result2 = result.scale(2d, false);
+      assertTrue("Must be the same image", result == result2);
+      img = result2.toImage();
+      assertNotNull("Image must exist", img);
+      width = img.getWidth();
+      height = img.getHeight();
+      assertEquals("width", 100, width, DELTA);
+      assertEquals("height", 100, height, DELTA);      
+   }   
+   
+   /**
+    * Test of scaling a existing image.
+    */
+   @Test
+   public void testScaledExistingImage2() {
+      System.out.println("SVGImageScaledTest : testScaledExistingImage2");
+      URL url = this.getClass().getResource("rect50.svg");
+      SVGImage result = SVGLoader.load(url);
+      Image img = result.toImage();
+      assertNotNull("Image must exist", img);
+      double width = img.getWidth();
+      double height = img.getHeight();
+      assertEquals("width", 50, width, DELTA);
+      assertEquals("height", 50, height, DELTA);
+      
+      SVGImage result2 = result.scale(2d);
+      assertTrue("Must be the same image", result == result2);
+      img = result2.toImage();
+      assertNotNull("Image must exist", img);
+      width = img.getWidth();
+      height = img.getHeight();
+      assertEquals("width", 100, width, DELTA);
+      assertEquals("height", 100, height, DELTA);      
+   }    
+}

--- a/test/org/girod/javafx/svgimage/SVGImageScaled3Test.java
+++ b/test/org/girod/javafx/svgimage/SVGImageScaled3Test.java
@@ -115,7 +115,7 @@ public class SVGImageScaled3Test {
       width = img.getWidth();
       height = img.getHeight();
       assertEquals("width", 100, width, DELTA);
-      assertEquals("height", 100, height, DELTA);      
+      assertEquals("height", 100, height, DELTA);    
    }   
    
    /**
@@ -142,4 +142,21 @@ public class SVGImageScaled3Test {
       assertEquals("width", 100, width, DELTA);
       assertEquals("height", 100, height, DELTA);      
    }    
+   
+   /**
+    * Test of generating a scaled image.
+    */
+   @Test
+   public void testScaledExistingImage3() {
+      System.out.println("SVGImageScaledTest : testScaledExistingImage3");
+      URL url = this.getClass().getResource("rect50.svg");
+      SVGImage result = SVGLoader.load(url);
+      result = result.scale(0.5d);
+      Image img = result.toImage();
+      assertNotNull("Image must exist", img);
+      double width = img.getWidth();
+      double height = img.getHeight();
+      assertEquals("width", 25, width, DELTA);
+      assertEquals("height", 25, height, DELTA);
+   }   
 }

--- a/web/source/fromsvg/svgimage.xml
+++ b/web/source/fromsvg/svgimage.xml
@@ -48,6 +48,16 @@
    
    <title level="2" title="examples" />
    <pre syntax="java">
+      SVGImage image = SVGLoader.load(&lt;the SVG URL&gt;);
+      SVGImage image2 = image.scale(2d); // the new image is the same object. image2 = image
+      SVGImage image3 = image.scale(2d, true); // the new image is another object. image3 != image
+   </pre>
+   
+   <title title="cloning a SVGImage" />
+   The <javadoc api="api" path="org.girod.javafx.svgimage.SVGImage" /> clas can be cloned. The cloning is performed through a scaling with a scale of 1.
+   
+   <title level="2" title="examples" />
+   <pre syntax="java">
       SVGImage img = SVGLoader.load(&lt;my SVG file&gt;);
       
       // a new SVGImage will be created with a scale of 2


### PR DESCRIPTION
Fix #90: Documentation/Behavior Mismatch: scale(double) returns a new instance instead of initial object